### PR TITLE
[minor] BLE-92 :: Server action for reading package.json's version property

### DIFF
--- a/src/app/play/[game]/menu.tsx
+++ b/src/app/play/[game]/menu.tsx
@@ -12,6 +12,7 @@ import { I18nProvider } from "@react-aria/i18n";
 import { Code, Spinner, useDisclosure } from "@heroui/react";
 import { Modal, ModalBody, ModalContent, ModalHeader } from "@heroui/react";
 import Image from "next/image";
+import getVersion from "@/core/action/version/get-version";
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
@@ -19,6 +20,8 @@ const Menu = (props: any) => {
     const date = parseDate(props.date);
     const { data, error, isLoading } = useSWR(`${process.env.SVC_PASSAGE}/daily/history`, fetcher);
     const {isOpen, onOpen, onOpenChange} = useDisclosure();
+    let version: string;
+    getVersion().then((appVersion) => version = appVersion);
 
     // const tooltip = <div className="px-1 py-2">
     //     <div className="text-small font-bold">{props.passage.icon} {themeMap[props.passage.icon].name}</div>
@@ -121,6 +124,9 @@ const Menu = (props: any) => {
                                     <p className="p-1 font-extralight">Use the number of verses to narrow your guess</p>
                                     <div className="flex mb-6 justify-center">
                                         <Image src="/guesses.png" alt="guesses" width={40 * 16} height={0}/>
+                                    </div>
+                                    <div className="mx-auto">
+                                        <p>App version: { version }</p>
                                     </div>
                                 </ModalBody>
                             </>

--- a/src/core/action/version/get-version.ts
+++ b/src/core/action/version/get-version.ts
@@ -1,0 +1,12 @@
+"use server"
+
+const { version } = require('../../../../package.json')
+
+let appVersion: string
+
+export default async function getVersion() {
+    if (!appVersion) {
+        appVersion = version
+    }
+    return appVersion
+}


### PR DESCRIPTION
Using a NextJS server action, we can 'require' package.json without pulling the entire thing into the front-end. From this action, we're then able to pass the version string wherever it's needed.

For now, I have put it in the 'How to play' modal:
<img width="879" height="785" alt="image" src="https://github.com/user-attachments/assets/54f1679c-d1d2-4016-91c3-e5e475a47032" />

---
Currently, there is a minor problem with this implementation. Sometimes, the version string won't be imported in time, but will be available on a re-render. One way to reproduce this can be found when opening and closing the DevTools panel of the browser:

[Screencast_20250720_120828.webm](https://github.com/user-attachments/assets/1414d2cb-4b61-41a1-a68b-4d50b0650ff0)
