### PR TITLE
Frontend UUID & Tracking Integration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,7 @@ const nextConfig = {
         SVC_BIBLE: process.env.NEXT_PUBLIC_SVC_BIBLE,
         SVC_PASSAGE: process.env.NEXT_PUBLIC_SVC_PASSAGE,
         SVC_USER: process.env.NEXT_PUBLIC_SVC_USER,
+        SVC_METRICS: process.env.NEXT_PUBLIC_SVC_METRICS,
         SIGNING_SECRET: process.env.NEXT_PUBLIC_SIGNING_SECRET
     },
     sassOptions: {

--- a/src/app/play/[game]/game.tsx
+++ b/src/app/play/[game]/game.tsx
@@ -20,6 +20,7 @@ import { GameState } from "@/core/model/state/game-state";
 import { toast } from "react-hot-toast";
 import { Button } from "@heroui/button";
 import Link from "next/link";
+import {UuidUtil} from "@/core/util/uuid-util";
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
@@ -233,6 +234,25 @@ export default function Game(props: any) {
             lastModified: new Date()
         }
         StateUtil.setGame(state);
+
+        if (won || limitReached) {
+            const uuid = UuidUtil.getOrCreate();
+            fetch(`${process.env.SVC_METRICS}/track/completion`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    uuid,
+                    passageId: passage.id,
+                    stars: starResult,
+                    guesses: updatedGuesses.length,
+                    won
+                }),
+            }).catch(error => {
+                console.error(error);
+            });
+        }
     }
 
     // fixme :: behaviour not correct
@@ -301,4 +321,3 @@ export default function Game(props: any) {
         );
     }
 }
-

--- a/src/core/action/metrics/get-daily-stats.ts
+++ b/src/core/action/metrics/get-daily-stats.ts
@@ -1,0 +1,8 @@
+"use server"
+
+import { DailyPlayerStats } from "@/core/model/metrics/daily-player-stats";
+
+export async function getDailyStats(): Promise<DailyPlayerStats> {
+    const response = await fetch(`${process.env.SVC_METRICS}/stats/daily-players`);
+    return await response.json();
+}

--- a/src/core/action/metrics/track-completion.ts
+++ b/src/core/action/metrics/track-completion.ts
@@ -1,0 +1,19 @@
+"use server"
+
+
+import { getUserId } from "@/core/util/auth-util";
+
+
+export async function trackCompletion(uuid: string): Promise<void> {
+    const userId = await getUserId();
+
+    const body = userId !== null
+        ? { userId: Number(userId) }
+        : { uuid };
+
+    await fetch(`${process.env.SVC_METRICS}/track/completion`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body)
+    });
+}

--- a/src/core/component/player-count.tsx
+++ b/src/core/component/player-count.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import React, { useEffect, useState } from "react";
+import { getDailyStats } from "@/core/action/metrics/get-daily-stats";
+import { DailyPlayerStats } from "@/core/model/metrics/daily-player-stats";
+
+const REFRESH_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+export default function PlayerCount() {
+    const [stats, setStats] = useState<DailyPlayerStats | null>(null);
+
+    const fetchStats = async () => {
+        const data = await getDailyStats();
+        setStats(data);
+    };
+
+    useEffect(() => {
+        fetchStats().catch(error => {
+            console.error("Failed to fetch player count:", error);
+            setStats(null);
+        });
+
+        const interval = setInterval(() => {
+            fetchStats().catch(error => {
+                console.error("Failed to refresh player count:", error);
+                // keep last known count — do not clear stats
+            });
+        }, REFRESH_INTERVAL_MS);
+
+        return () => clearInterval(interval);
+    }, []);
+
+    if (stats === null) {
+        return null;
+    }
+
+    return <p>{stats.totalCount.toLocaleString()} people played today</p>;
+}

--- a/src/core/model/metrics/daily-player-stats.ts
+++ b/src/core/model/metrics/daily-player-stats.ts
@@ -1,0 +1,11 @@
+/**
+ * Daily Player Stats Model
+ * @since 28th February 2026
+ */
+export type DailyPlayerStats = {
+    date: string
+    totalCount: number
+    loggedInCount: number
+    anonymousCount: number
+    lastUpdated: string | null
+}

--- a/src/core/util/uuid-util.ts
+++ b/src/core/util/uuid-util.ts
@@ -1,0 +1,22 @@
+"use client"
+
+import { StorageUtil } from "@/core/util/storage-util";
+
+const UUID_KEY = "kingdom:player:uuid";
+
+export class UuidUtil {
+
+    static getOrCreate(): string {
+
+        const existing = StorageUtil.retrieve(UUID_KEY)
+
+        if (existing !== null) {
+
+            return JSON.parse(existing)
+        }
+
+        const uuid = crypto.randomUUID()
+        StorageUtil.save(UUID_KEY, uuid)
+        return uuid
+    }
+}


### PR DESCRIPTION
## Summary
- Add UUID utility to generate/retrieve a persistent player UUID from localStorage
- Integrate non-blocking tracking call on game completion (`/track/completion`)
- Add `PlayerCount` component that displays daily player count with 5-minute auto-refresh
- Add server actions for tracking completion and fetching daily stats
- Wire `SVC_METRICS` environment variable through `next.config.js`

## Changes
- `src/core/util/uuid-util.ts` — UUID generation/storage via `crypto.randomUUID()` and localStorage
- `src/core/action/metrics/track-completion.ts` — server action to POST game completion to Analytics Service
- `src/core/action/metrics/get-daily-stats.ts` — server action to GET daily player stats
- `src/core/component/player-count.tsx` — displays "X,XXX people played today", refreshes every 5 minutes
- `src/core/model/metrics/daily-player-stats.ts` — response model for daily stats
- `src/app/play/[game]/game.tsx` — calls tracking on game completion (fire-and-forget, non-blocking)
- `next.config.js` — exposes `SVC_METRICS` env var

## Test plan
- [ ] Play a game to completion and verify UUID is stored in localStorage under `kingdom:player:uuid`
- [ ] Confirm `POST /track/completion` appears in the Network tab on game completion
- [ ] Verify game completes normally if Analytics Service is stopped (graceful degradation)
- [ ] Confirm `PlayerCount` component renders and refreshes every 5 minutes