### PR TITLE
Add metrics tracking for game completions and daily player stats

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,7 @@ const nextConfig = {
         SVC_BIBLE: process.env.NEXT_PUBLIC_SVC_BIBLE,
         SVC_PASSAGE: process.env.NEXT_PUBLIC_SVC_PASSAGE,
         SVC_USER: process.env.NEXT_PUBLIC_SVC_USER,
+        SVC_METRICS: process.env.NEXT_PUBLIC_SVC_METRICS,
         SIGNING_SECRET: process.env.NEXT_PUBLIC_SIGNING_SECRET
     },
     sassOptions: {

--- a/src/app/play/[game]/game.tsx
+++ b/src/app/play/[game]/game.tsx
@@ -20,6 +20,7 @@ import { GameState } from "@/core/model/state/game-state";
 import { toast } from "react-hot-toast";
 import { Button } from "@heroui/button";
 import Link from "next/link";
+import {UuidUtil} from "@/core/util/uuid-util";
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
@@ -233,6 +234,25 @@ export default function Game(props: any) {
             lastModified: new Date()
         }
         StateUtil.setGame(state);
+
+        if (won || limitReached) {
+            const uuid = UuidUtil.getOrCreate();
+            fetch(`${process.env.SVC_METRICS}/track/completion`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    uuid,
+                    passageId: passage.id,
+                    stars: starResult,
+                    guesses: updatedGuesses.length,
+                    won
+                }),
+            }).catch(error => {
+                console.error(error);
+            });
+        }
     }
 
     // fixme :: behaviour not correct
@@ -301,4 +321,3 @@ export default function Game(props: any) {
         );
     }
 }
-

--- a/src/app/stats/metrics.tsx
+++ b/src/app/stats/metrics.tsx
@@ -82,4 +82,5 @@ const Metrics = (props: Readonly<Props>) => {
     );
 };
 
+
 export default Metrics;

--- a/src/core/action/metrics/get-daily-stats.ts
+++ b/src/core/action/metrics/get-daily-stats.ts
@@ -1,0 +1,8 @@
+"use server"
+
+import { DailyPlayerStats } from "@/core/model/metrics/daily-player-stats";
+
+export async function getDailyStats(): Promise<DailyPlayerStats> {
+    const response = await fetch(`${process.env.SVC_METRICS}/stats/daily-players`);
+    return await response.json();
+}

--- a/src/core/action/metrics/track-completion.ts
+++ b/src/core/action/metrics/track-completion.ts
@@ -1,0 +1,19 @@
+"use server"
+
+
+import { getUserId } from "@/core/util/auth-util";
+
+
+export async function trackCompletion(uuid: string): Promise<void> {
+    const userId = await getUserId();
+
+    const body = userId !== null
+        ? { userId: Number(userId) }
+        : { uuid };
+
+    await fetch(`${process.env.SVC_METRICS}/track/completion`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body)
+    });
+}

--- a/src/core/component/player-count.tsx
+++ b/src/core/component/player-count.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import React, { useEffect, useState } from "react";
+import { getDailyStats } from "@/core/action/metrics/get-daily-stats";
+import { DailyPlayerStats } from "@/core/model/metrics/daily-player-stats";
+
+const REFRESH_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+export default function PlayerCount() {
+    const [stats, setStats] = useState<DailyPlayerStats | null>(null);
+
+    const fetchStats = async () => {
+        const data = await getDailyStats();
+        setStats(data);
+    };
+
+    useEffect(() => {
+        fetchStats().catch(error => {
+            console.error("Failed to fetch player count:", error);
+            setStats(null);
+        });
+
+        const interval = setInterval(() => {
+            fetchStats().catch(error => {
+                console.error("Failed to refresh player count:", error);
+                // keep last known count — do not clear stats
+            });
+        }, REFRESH_INTERVAL_MS);
+
+        return () => clearInterval(interval);
+    }, []);
+
+    if (stats === null) {
+        return null;
+    }
+
+    return <p>{stats.totalCount.toLocaleString()} people played today</p>;
+}

--- a/src/core/model/metrics/daily-player-stats.ts
+++ b/src/core/model/metrics/daily-player-stats.ts
@@ -1,0 +1,11 @@
+/**
+ * Daily Player Stats Model
+ * @since 28th February 2026
+ */
+export type DailyPlayerStats = {
+    date: string
+    totalCount: number
+    loggedInCount: number
+    anonymousCount: number
+    lastUpdated: string | null
+}

--- a/src/core/util/uuid-util.ts
+++ b/src/core/util/uuid-util.ts
@@ -1,0 +1,22 @@
+"use client"
+
+import { StorageUtil } from "@/core/util/storage-util";
+
+const UUID_KEY = "kingdom:player:uuid";
+
+export class UuidUtil {
+
+    static getOrCreate(): string {
+
+        const existing = StorageUtil.retrieve(UUID_KEY)
+
+        if (existing !== null) {
+
+            return JSON.parse(existing)
+        }
+
+        const uuid = crypto.randomUUID()
+        StorageUtil.save(UUID_KEY, uuid)
+        return uuid
+    }
+}


### PR DESCRIPTION
This pull request adds new metrics tracking and reporting features to the application, including tracking game completion events and displaying the daily player count. It introduces utility functions and components for handling anonymous user identification and fetching player statistics, and integrates these into the game flow.

**Metrics tracking and reporting:**

* Added a new `UuidUtil` utility in `uuid-util.ts` to generate and persist a unique anonymous user ID in local storage for tracking purposes.
* Updated the main game logic in `game.tsx` to send a POST request to the metrics service when a game is completed or the guess limit is reached, including user UUID, passage ID, stars, guesses, and win status. ([src/app/play/[game]/game.tsxR23](diffhunk://#diff-97257bde8ac637fc902f9d0ec92cb655e4b5dc03d603e82d501f7e9cb0f1a4faR23), [src/app/play/[game]/game.tsxR237-R255](diffhunk://#diff-97257bde8ac637fc902f9d0ec92cb655e4b5dc03d603e82d501f7e9cb0f1a4faR237-R255))
* Introduced a server action `track-completion.ts` to send completion events to the metrics service, supporting both logged-in and anonymous users.

**Player statistics display:**

* Added a new `PlayerCount` client component that fetches and displays the number of players for the current day, refreshing every 5 minutes.
* Created a server action `get-daily-stats.ts` to fetch daily player statistics from the metrics service, and defined the `DailyPlayerStats` model. [[1]](diffhunk://#diff-4f88397d47346bfcdea3de1ef11ef5e2ff6c49edb8236e08bce9c4639e1bba90R1-R8) [[2]](diffhunk://#diff-ca49c377c79716b775e90bb26d4a50792157d05030d3273e78e33d6ffaa6b498R1-R11)